### PR TITLE
Extra validation check for manifest tags

### DIFF
--- a/Skyline.DataMiner.CICD.Tools.GitHubToCatalogYaml/CatalogManager.cs
+++ b/Skyline.DataMiner.CICD.Tools.GitHubToCatalogYaml/CatalogManager.cs
@@ -184,13 +184,19 @@
                 catalogYaml.Tags = new List<string>();
             }
 
+            if(catalogYaml.Tags.Count >= 5)
+            {
+                logger.LogDebug("Catalog YAML has the max amount of tags already. Skipping the adding GitHub topics step.");
+                return;
+            }
+
             var topics = await service.GetRepositoryTopicsAsync();
             if (topics is { Count: > 0 })
             {
                 catalogYaml.Tags.AddRange(topics);
 
                 // Remove duplicates
-                catalogYaml.Tags = catalogYaml.Tags.Distinct().ToList();
+                catalogYaml.Tags = catalogYaml.Tags.Distinct().Take(5).ToList();
                 logger.LogDebug("Distinct GitHub Topics found and applied.");
             }
         }


### PR DESCRIPTION
Noticed that for one of my repos the tool was adding all the topics to the tags of the manifest.yml. But the documentation mentions you can only have 5 and the original manifest.yml already has 5 tags.  So with the now added topics the total tags were 7. I'm not sure this will actually result in an issue though.

If this is not an issue and the catalog api just drops the remaining tags, you can just reject this pull request. 