### PR TITLE
Update owners comment in CatalogYaml.cs

### DIFF
--- a/Skyline.DataMiner.CICD.Tools.GitHubToCatalogYaml/CatalogYaml.cs
+++ b/Skyline.DataMiner.CICD.Tools.GitHubToCatalogYaml/CatalogYaml.cs
@@ -25,7 +25,6 @@
 
         private const string ownersComment = "[Optional]\r\n" +
                                              "People who are responsible for this Catalog item. Might be developers, but this is not required.\r\n" +
-                                             "Format: 'name <email> (url)'\r\n" +
                                              "  The name is required; max 256 characters.\r\n" +
                                              "  The email and url are optional, and should be in valid email/URL formats.";
 


### PR DESCRIPTION
Comment is not clear. People are incorrectly using the name field to get to this format, while they should use the separate fields.

Also changed in docs.